### PR TITLE
Fixed always empty query results

### DIFF
--- a/R/functions.R
+++ b/R/functions.R
@@ -225,7 +225,6 @@ searchAtlasExperiments <- function( properties, species = NULL ) {
     queryURL <- paste( 
         aeAPIbase,
         paste( properties, collapse = "+OR+" ),
-        "&gxa=TRUE",
         sep = ""
     )
     


### PR DESCRIPTION
API always returns empty results when using searchAtlasExperiments. Fixed by removing gxa=TRUE from API query.