### PR TITLE
Fixes current error in Bioconductor 

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: ExpressionAtlas
-Version: 1.15.1
+Version: 1.15.2
 Date: 2018/05/09
 Title: Download datasets from EMBL-EBI Expression Atlas
 Author: Maria Keays

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,7 +11,7 @@ Description: This package is for searching for datasets in EMBL-EBI Expression
     data is contained in an ExpressionSet or MAList object.
 biocViews: ExpressionData, ExperimentData, SequencingData,
         MicroarrayData, ArrayExpress
-Depends: R (>= 3.2.0), methods, Biobase, SummarizedExperiment, limma,
+Depends: R (>= 4.1.0), methods, Biobase, SummarizedExperiment, limma,
         S4Vectors, xml2
 Imports: utils, XML, httr
 Suggests: knitr, testthat, rmarkdown

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,9 +1,9 @@
 Package: ExpressionAtlas
-Version: 1.15.2
-Date: 2018/05/09
+Version: 1.21.1
+Date: 2021/10/04
 Title: Download datasets from EMBL-EBI Expression Atlas
 Author: Maria Keays
-Maintainer: Suhaib Mohammed <suhaib@ebi.ac.uk>
+Maintainer: Pedro Madrigal <pmadrigal@ebi.ac.uk>
 Description: This package is for searching for datasets in EMBL-EBI Expression
     Atlas, and downloading them into R for further analysis. Each Expression Atlas
     dataset is represented as a SimpleList object with one element per platform.
@@ -11,7 +11,8 @@ Description: This package is for searching for datasets in EMBL-EBI Expression
     data is contained in an ExpressionSet or MAList object.
 biocViews: ExpressionData, ExperimentData, SequencingData,
         MicroarrayData, ArrayExpress
-Depends: R (>= 3.2.0), methods, Biobase, SummarizedExperiment, limma, S4Vectors, xml2
+Depends: R (>= 3.2.0), methods, Biobase, SummarizedExperiment, limma,
+        S4Vectors, xml2
 Imports: utils, XML, httr
 Suggests: knitr, testthat, rmarkdown
 VignetteBuilder: knitr

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,7 +11,7 @@ Description: This package is for searching for datasets in EMBL-EBI Expression
     data is contained in an ExpressionSet or MAList object.
 biocViews: ExpressionData, ExperimentData, SequencingData,
         MicroarrayData, ArrayExpress
-Depends: R (>= 4.1.0), methods, Biobase, SummarizedExperiment, limma,
+Depends: R (>= 4.1.1), methods, Biobase, SummarizedExperiment, limma,
         S4Vectors, xml2
 Imports: utils, XML, httr
 Suggests: knitr, testthat, rmarkdown

--- a/R/functions.R
+++ b/R/functions.R
@@ -225,7 +225,7 @@ searchAtlasExperiments <- function( properties, species = NULL ) {
     queryURL <- paste( 
         aeAPIbase,
         paste( properties, collapse = "+OR+" ),
-        "&gxa=TRUE",
+        #"&gxa=TRUE",
         sep = ""
     )
     

--- a/R/functions.R
+++ b/R/functions.R
@@ -225,7 +225,6 @@ searchAtlasExperiments <- function( properties, species = NULL ) {
     queryURL <- paste( 
         aeAPIbase,
         paste( properties, collapse = "+OR+" ),
-        #"&gxa=TRUE",
         sep = ""
     )
     

--- a/man/searchAtlasExperiments.Rd
+++ b/man/searchAtlasExperiments.Rd
@@ -25,7 +25,7 @@
 \examples{
     
     # Search for experiments on salt in rice.
-    atlasRes <- searchAtlasExperiments( "salt", "Oryza sativa" )
+    atlasRes <- searchAtlasExperiments( properties = "salt", species = "rice"  )
 
     # Download data for all experiments found.
     atlasData <- getAtlasData( atlasRes$Accession )


### PR DESCRIPTION
Fixes current CHECK error in inreport for  BioC 3.13 and BioC 3.14 (devel)
```
Hide quoted text
> atlasRes <- searchAtlasExperiments(properties = "salt", species = "rice")
Searching for Expression Atlas experiments matching your query ...
Query successful.
No results found. Cannot continue.
````
that is not reporting any result. 

Current successful Query in GXA should use the URL:
```
https://www.ebi.ac.uk/arrayexpress/xml/v2/experiments?keywords=salt&species=rice
```
instead of
```
https://www.ebi.ac.uk/arrayexpress/xml/v2/experiments?keywords=salt&gxa=TRUE&species=rice
```

