### PR TITLE
Fix for multiple platform build/check report for BioC 3.15

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: ExpressionAtlas
-Version: 1.21.1
+Version: 1.21.3
 Date: 2021/10/04
 Title: Download datasets from EMBL-EBI Expression Atlas
 Author: Maria Keays

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: ExpressionAtlas
-Version: 1.15.1
+Version: 1.15.2
 Date: 2018/05/09
 Title: Download datasets from EMBL-EBI Expression Atlas
 Author: Maria Keays

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,7 +11,7 @@ Description: This package is for searching for datasets in EMBL-EBI Expression
     data is contained in an ExpressionSet or MAList object.
 biocViews: ExpressionData, ExperimentData, SequencingData,
         MicroarrayData, ArrayExpress
-Depends: R (>= 3.2.0), methods, Biobase, SummarizedExperiment, limma,
+Depends: R (>= 4.1.0), methods, Biobase, SummarizedExperiment, limma,
         S4Vectors, xml2
 Imports: utils, XML, httr
 Suggests: knitr, testthat, rmarkdown

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: ExpressionAtlas
-Version: 1.21.4
-Date: 2021/10/11
+Version: 1.21.5
+Date: 2022/04/06
 Title: Download datasets from EMBL-EBI Expression Atlas
 Author: Maria Keays
 Maintainer: Pedro Madrigal <pmadrigal@ebi.ac.uk>

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: ExpressionAtlas
-Version: 1.21.3
-Date: 2021/10/04
+Version: 1.21.4
+Date: 2021/10/11
 Title: Download datasets from EMBL-EBI Expression Atlas
 Author: Maria Keays
 Maintainer: Pedro Madrigal <pmadrigal@ebi.ac.uk>

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,9 +1,9 @@
 Package: ExpressionAtlas
-Version: 1.15.2
-Date: 2018/05/09
+Version: 1.21.1
+Date: 2021/10/04
 Title: Download datasets from EMBL-EBI Expression Atlas
 Author: Maria Keays
-Maintainer: Suhaib Mohammed <suhaib@ebi.ac.uk>
+Maintainer: Pedro Madrigal <pmadrigal@ebi.ac.uk>
 Description: This package is for searching for datasets in EMBL-EBI Expression
     Atlas, and downloading them into R for further analysis. Each Expression Atlas
     dataset is represented as a SimpleList object with one element per platform.
@@ -11,7 +11,8 @@ Description: This package is for searching for datasets in EMBL-EBI Expression
     data is contained in an ExpressionSet or MAList object.
 biocViews: ExpressionData, ExperimentData, SequencingData,
         MicroarrayData, ArrayExpress
-Depends: R (>= 3.2.0), methods, Biobase, SummarizedExperiment, limma, S4Vectors, xml2
+Depends: R (>= 3.2.0), methods, Biobase, SummarizedExperiment, limma,
+        S4Vectors, xml2
 Imports: utils, XML, httr
 Suggests: knitr, testthat, rmarkdown
 VignetteBuilder: knitr

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,7 +11,7 @@ Description: This package is for searching for datasets in EMBL-EBI Expression
     data is contained in an ExpressionSet or MAList object.
 biocViews: ExpressionData, ExperimentData, SequencingData,
         MicroarrayData, ArrayExpress
-Depends: R (>= 4.1.0), methods, Biobase, SummarizedExperiment, limma,
+Depends: R (>= 4.1.1), methods, Biobase, SummarizedExperiment, limma,
         S4Vectors, xml2
 Imports: utils, XML, httr
 Suggests: knitr, testthat, rmarkdown

--- a/R/functions.R
+++ b/R/functions.R
@@ -225,6 +225,7 @@ searchAtlasExperiments <- function( properties, species = NULL ) {
     queryURL <- paste( 
         aeAPIbase,
         paste( properties, collapse = "+OR+" ),
+        "&gxa=TRUE",
         sep = ""
     )
     

--- a/R/functions.R
+++ b/R/functions.R
@@ -225,7 +225,7 @@ searchAtlasExperiments <- function( properties, species = NULL ) {
     queryURL <- paste( 
         aeAPIbase,
         paste( properties, collapse = "+OR+" ),
-        "&gxa=TRUE",
+        #"&gxa=TRUE",
         sep = ""
     )
     

--- a/R/functions.R
+++ b/R/functions.R
@@ -225,7 +225,6 @@ searchAtlasExperiments <- function( properties, species = NULL ) {
     queryURL <- paste( 
         aeAPIbase,
         paste( properties, collapse = "+OR+" ),
-        #"&gxa=TRUE",
         sep = ""
     )
     

--- a/R/functions.R
+++ b/R/functions.R
@@ -76,7 +76,7 @@ getAtlasExperiment <- function( experimentAccession ) {
     close( connection )
 
     # Make sure experiment summary object exists before trying to return it.
-    getResult <- try( get( "experimentSummary" ) )
+    getResult <- try( get( "experiment_summary" ) )
 
     if( class( getResult ) == "try-error" ) {
         
@@ -94,7 +94,7 @@ getAtlasExperiment <- function( experimentAccession ) {
     )
 
     # Return the experiment summary.
-    expSum <- get( "experimentSummary" )
+    expSum <- get( "experiment_summary" )
 
     return( expSum )
 }

--- a/man/searchAtlasExperiments.Rd
+++ b/man/searchAtlasExperiments.Rd
@@ -25,7 +25,7 @@
 \examples{
     
     # Search for experiments on salt in rice.
-    atlasRes <- searchAtlasExperiments( "salt", "Oryza sativa" )
+    atlasRes <- searchAtlasExperiments( properties = "salt", species = "rice"  )
 
     # Download data for all experiments found.
     atlasData <- getAtlasData( atlasRes$Accession )


### PR DESCRIPTION
With the latest Expression Atlas release 38, a change was introduced [here](https://github.com/ebi-gene-expression-group/bulk-recalculations/commit/3ada234b25bae34592fbe6515f301ef2ce0b98f8) in the name of the object that saves the Experiment Summary, from `save( experimentSummary, file = args$output )` to `save(experiment_summary, file = args$output)`. This has triggered build/check fails on the `ExpressionAtlas` Bioconductor package. This PR aims to fix that.


