### PR TITLE
Add tests to devel branch in Bioconductor

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: ExpressionAtlas
-Version: 1.25.0
-Date: 2022/04/06
+Version: 1.25.1
+Date: 2022/05/12
 Title: Download datasets from EMBL-EBI Expression Atlas
 Author: Maria Keays
 Maintainer: Pedro Madrigal <pmadrigal@ebi.ac.uk>

--- a/tests/testthat/test_functions.R
+++ b/tests/testthat/test_functions.R
@@ -1,10 +1,39 @@
 
-context( "Testing functions from ExpressionAtlas package" )
-
 test_that( "Accession validation returns true or false at the right times", {
     
     expect_true( .isValidExperimentAccession( "E-MTAB-3007" ) )
     expect_false( .isValidExperimentAccession( "DRP000391" ) )
     expect_false( .isValidExperimentAccession( ) )
+})
 
-} )
+test_that("check test data", {
+
+    data( "atlasRes" )
+    data( "rnaseqExps" )
+    expect_equal( nrow(atlasRes), 3 )
+    expect_equal( ncol(atlasRes), 4 )
+    expect_equal( names(rnaseqExps), "E-MTAB-1625" )
+})
+
+# the following tests require internet connection
+
+check_api <- function() {
+    if ( is.character(getURL("www.ebi.ac.uk/arrayexpress/")) == FALSE ) {
+        skip("API not available")
+    }
+}
+
+test_that("Download the experiment summary for E-GEOD-11175", {
+
+    check_api()
+    geod11175 <- getAtlasExperiment( "E-GEOD-11175" )
+    expect_equal( names( geod11175 ), "A-AFFY-126" )
+})
+
+test_that("Search for cancer datasets in human", {
+
+    check_api()
+    cancerRes <- searchAtlasExperiments( properties = "cancer", species = "human"  )
+    expect_false( ( nrow(cancerRes) == 0 ) ) 
+
+})

--- a/tests/testthat/test_functions.R
+++ b/tests/testthat/test_functions.R
@@ -35,5 +35,4 @@ test_that("Search for cancer datasets in human", {
     check_api()
     cancerRes <- searchAtlasExperiments( properties = "cancer", species = "human"  )
     expect_false( ( nrow(cancerRes) == 0 ) ) 
-
 })


### PR DESCRIPTION
The goal of this PR is to add more formal automated tests to the `ExpressionAtlas` package using the `testthat` package.

Features:
- the use of [testthat::context()](https://testthat.r-lib.org/reference/context.html) is now discouraged.
- skip tests without failure if offline