### PR TITLE
improve level of strictness when comparing a computation to a reference value in the tests

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,9 +1,9 @@
 Package: ExpressionAtlas
-Version: 1.25.2
-Date: 2022/05/13
+Version: 1.25.3
+Date: 2022/05/16
 Title: Download datasets from EMBL-EBI Expression Atlas
 Author: Maria Keays
-Maintainer: Pedro Madrigal <pmadrigal@ebi.ac.uk>
+Maintainer: Pedro Madrigal <gene-expression@ebi.ac.uk>
 Description: This package is for searching for datasets in EMBL-EBI Expression
     Atlas, and downloading them into R for further analysis. Each Expression Atlas
     dataset is represented as a SimpleList object with one element per platform.

--- a/tests/testthat/test_functions.R
+++ b/tests/testthat/test_functions.R
@@ -12,7 +12,7 @@ test_that("check test data", {
     data( "rnaseqExps" )
     expect_equal( nrow(atlasRes), 3 )
     expect_equal( ncol(atlasRes), 4 )
-    expect_equal( names(rnaseqExps), "E-MTAB-1625" )
+    expect_identical( names(rnaseqExps), "E-MTAB-1625" )
 })
 
 # the following tests require internet connection
@@ -27,7 +27,7 @@ test_that("Download the experiment summary for E-GEOD-11175", {
 
     check_api()
     geod11175 <- getAtlasExperiment( "E-GEOD-11175" )
-    expect_equal( names( geod11175 ), "A-AFFY-126" )
+    expect_identical( names( geod11175 ), "A-AFFY-126" )
 })
 
 test_that("Search for cancer datasets in human", {


### PR DESCRIPTION
Convert `expect_equal` -> `expect_identical`

This is motivated by an error occurring currently in one of the platforms for the daily bioc builds:

```
══ Failed tests ════════════════════════════════════════════════════════════════
── Failure (test_functions.R:30:5): Download the experiment summary for E-GEOD-11175 ──
names(geod11175) not equal to "A-AFFY-126".
target is NULL, current is character
```
it might be unrelated - in any case this change improves the code.